### PR TITLE
Mock TCP Client

### DIFF
--- a/control/src/livex/furnace/controller.py
+++ b/control/src/livex/furnace/controller.py
@@ -71,8 +71,6 @@ class FurnaceController():
         # Interval is smaller than period so that tcp stream can be cleared and not maintained
         self.bg_stream_task_interval = (1/self.pid_frequency)/2
 
-        logging.debug(f"#####################\npid_freq:{self.pid_frequency}, stream interval: {self.bg_stream_task_interval}")
-
         # Set the background task counters to zero
         self.background_thread_counter = 0
 

--- a/control/src/livex/mockModbusClient.py
+++ b/control/src/livex/mockModbusClient.py
@@ -152,7 +152,6 @@ class MockModbusClient:
 
         return MockResponse(registers=builder.to_registers())
 
-
 class MockResponse:
     """Response object to replicate common pymodbus responses."""
 
@@ -269,3 +268,28 @@ class MockPLC:
                 pid_base_sp += autosp_rate
             # 'Write' new setpoint back to register
             self.client.registers[modAddr.pid_setpoint_a_hold] = pid_base_sp
+
+
+class MockTCPClient:
+
+    def __init__(self, mockPLC):
+        self.buffer = b'\x00' * 128
+        self.plc = mockPLC
+        self.counter = 0
+
+    def connect(self, address):
+        pass
+
+    def settimeout(self, timeout):
+        pass
+
+    def send(self, data):
+        pass
+
+    def recv(self, buffersize):
+        self.counter += 1
+        temp = self.plc.temp
+        return [self.counter, temp]
+
+    def close(self):
+        pass


### PR DESCRIPTION
Additionally mocking out the TCP client (even if it is very much a shell) gives some slightly better behaviour on the acquisition, but mostly avoids any hangs or errors when hardware is expected and not found. 

This small fix should cover most use cases - the application launches, and lets you use either of the acquisition buttons on the UI as-is.  
The fake data is not written to a file - but the metadata still should be, if testing that is desirable.