### PR TITLE
49 cam UI processing fixes

### DIFF
--- a/control/src/livex/live_data/controller.py
+++ b/control/src/livex/live_data/controller.py
@@ -29,7 +29,8 @@ class LiveDataController(BaseController):
             {'x': int(width), 'y': int(height)}  # generate x/y dict
             for resolution in options.get('camera_resolution', '4096x2304').split(',') # get resolutions
             for width, height in [resolution.strip().split("x")] # each resolution split into array
-        ]        
+        ]
+        pixel_bytes = options.get('pixel_size', 2)
 
         self.tree = {
             '_image': {}
@@ -42,7 +43,7 @@ class LiveDataController(BaseController):
             name = self.names[i]
             resolution = resolutions[i]
             self.processors.append(
-                LiveDataProcessor(endpoints[i], resolution)
+                LiveDataProcessor(endpoints[i], resolution, pixel_bytes)
             )
 
             proc = self.processors[i]

--- a/control/src/livex/live_data/live_data_adapter.py
+++ b/control/src/livex/live_data/live_data_adapter.py
@@ -1,8 +1,34 @@
 
 from livex.base_adapter import BaseAdapter
 from livex.live_data.controller import LiveDataController, LiveXError
+from livex.base_adapter import ApiAdapterResponse
 
 class LiveDataAdapter(BaseAdapter):
 
     controller_cls = LiveDataController
     error_cls = LiveXError
+
+    def get(self, path, with_metadata=False):
+        """BaseAdapter get override to handle image processing."""
+        import logging
+        try:
+            levels = path.split('/')
+            if levels[0] == '_image':
+
+                img_bytes = self.controller.get_image_from_processor_name(levels[1])
+                if not img_bytes or not isinstance(img_bytes, (bytes, bytearray)):
+                    return ApiAdapterResponse(b"", content_type="text/plain", status_code=200)
+
+                response=img_bytes
+                content_type="image/jpeg"
+                logging.warning(f"response type: {type(response)} : {response}")
+            else:
+                response = self.controller.get(path, with_metadata=False)
+                content_type="application/json"
+            status_code = 200
+        except self.error_cls as error:
+            response = {"error":str(error)}
+            content_type = "application/json"
+            status_code = 400
+
+        return ApiAdapterResponse(response, content_type=content_type, status_code=status_code)

--- a/control/src/livex/live_data/live_data_adapter.py
+++ b/control/src/livex/live_data/live_data_adapter.py
@@ -25,7 +25,7 @@ class LiveDataAdapter(BaseAdapter):
                     return ApiAdapterResponse(b"", content_type="text/plain", status_code=200)
 
                 response=img_bytes
-                content_type="image/jpeg"
+                content_type="image/png"
             else:
                 response = self.controller.get(path, with_metadata=False)
                 content_type="application/json"

--- a/control/src/livex/live_data/live_data_adapter.py
+++ b/control/src/livex/live_data/live_data_adapter.py
@@ -16,7 +16,6 @@ class LiveDataAdapter(BaseAdapter):
             img_bytes = None
             # structure for intercept: _image/<name>/<image or histogram>
             if levels[0] == '_image':
-                logging.warning(f"levels: {levels}")
                 if levels[-1] == 'image':
                     img_bytes = self.controller.get_image_from_processor_name(levels[1], 'image')
                 elif levels[-1] == 'histogram':

--- a/control/src/livex/live_data/live_data_adapter.py
+++ b/control/src/livex/live_data/live_data_adapter.py
@@ -13,15 +13,20 @@ class LiveDataAdapter(BaseAdapter):
         import logging
         try:
             levels = path.split('/')
+            img_bytes = None
+            # structure for intercept: _image/<name>/<image or histogram>
             if levels[0] == '_image':
+                logging.warning(f"levels: {levels}")
+                if levels[-1] == 'image':
+                    img_bytes = self.controller.get_image_from_processor_name(levels[1], 'image')
+                elif levels[-1] == 'histogram':
+                    img_bytes = self.controller.get_image_from_processor_name(levels[1], 'histogram')
 
-                img_bytes = self.controller.get_image_from_processor_name(levels[1])
                 if not img_bytes or not isinstance(img_bytes, (bytes, bytearray)):
                     return ApiAdapterResponse(b"", content_type="text/plain", status_code=200)
 
                 response=img_bytes
                 content_type="image/jpeg"
-                logging.warning(f"response type: {type(response)} : {response}")
             else:
                 response = self.controller.get(path, with_metadata=False)
                 content_type="application/json"

--- a/control/src/livex/live_data/processor.py
+++ b/control/src/livex/live_data/processor.py
@@ -171,10 +171,9 @@ class LiveDataProcessor():
         plt.close(fig)
 
         _, histImage = cv2.imencode('.jpg', histData)
-        zipped_data = base64.b64encode(histImage)
         while (not self.hist_queue.empty()):
             self.hist_queue.get()
-        self.hist_queue.put(zipped_data.decode('utf-8'))
+        self.hist_queue.put(histImage.tobytes())
 
     def get_colour_map(self):
         """Get the colour map based on the colour string. Defaults to 'bone' (greyscale)."""

--- a/control/src/livex/live_data/processor.py
+++ b/control/src/livex/live_data/processor.py
@@ -17,11 +17,12 @@ from odin_data.control.ipc_channel import IpcChannel
 class LiveDataProcessor():
     """Class to process image data received on a multiprocess that it instantiates."""
 
-    def __init__(self, endpoint, resolution, size_x=2048, size_y=1152, colour='bone'):
+    def __init__(self, endpoint, resolution, pixel_bytes, size_x=2048, size_y=1152, colour='bone'):
         """Initialise the LiveDataProcessor object.
         This method constructs the Queue, Pipes and Process necessary for multiprocessing.
         :param endpoint: string representation of endpoint for image data.
         :param resolution: dict ({'x': x, 'y': y}) of maximum image dimensions
+        :param pixel_bytes: number of bytes per pixel in image data
         :param size_x: integer width of output image in pixels (default 640).
         :param size_y: integer height of output image in pixels (default 480).
         :param colour: string of opencv colourmap label (default 'bone').
@@ -36,6 +37,7 @@ class LiveDataProcessor():
         self.colour = colour
 
         self.resolution_percent = 100
+        self.pixel_bytes = pixel_bytes
 
         self.image = 0
         self.histogram = None
@@ -112,69 +114,74 @@ class LiveDataProcessor():
 
         dtype = 'float32' if header['dtype'] == "float" else header['dtype']
 
-        # Check for image compression by checking raw data size. Decompress if needed
-        # Currently assumes bytes-per-pixel of 2
-        if len(msg[1]) != (self.max_size_x*self.max_size_y*2):
-            uncompressed_data = blosc.decompress(msg[1])
-            data = np.fromstring(uncompressed_data, dtype=dtype)
-        else:
-            data = np.frombuffer(msg[1], dtype=dtype)  # Otherwise, grab the data as-is
+        try:
+            # Check for image compression by checking raw data size. Decompress if needed
+            # Currently assumes bytes-per-pixel of 2
+            if len(msg[1]) != (self.max_size_x*self.max_size_y*self.pixel_bytes):
+                uncompressed_data = blosc.decompress(msg[1])
+                data = np.fromstring(uncompressed_data, dtype=dtype)
+            else:
+                data = np.frombuffer(msg[1], dtype=dtype)  # Otherwise, grab the data as-is
 
-        # For histogram, it's easier to clip the data before reshaping it
-        clipped_ = np.clip(data, self.clipping['min'], self.clipping['max'])
-        # After clipping, scale data back out to full range
-        scaled_data = ((clipped_ - self.clipping['min']) / (self.clipping['max'] - self.clipping['min'])) * 65535
+            # For histogram, it's easier to clip the data before reshaping it
+            clipped_ = np.clip(data, self.clipping['min'], self.clipping['max'])
+            # After clipping, scale data back out to full range
+            scaled_data = ((clipped_ - self.clipping['min']) / (self.clipping['max'] - self.clipping['min'])) * 65535
 
-        reshaped_data = scaled_data.reshape((2304, 4096)) # ORCA dimensions
+            reshaped_data = scaled_data.reshape((2304, 4096)) # ORCA dimensions
 
-        # OpenCV operations
-        resized_data = cv2.resize(reshaped_data, (self.size_x, self.size_y))
+            # OpenCV operations
+            resized_data = cv2.resize(reshaped_data, (self.size_x, self.size_y))
 
-        roi_data = resized_data[self.roi['y_lower']:self.roi['y_upper'],
-                        self.roi['x_lower']:self.roi['x_upper']]
+            roi_data = resized_data[self.roi['y_lower']:self.roi['y_upper'],
+                            self.roi['x_lower']:self.roi['x_upper']]
 
-        colour_data = cv2.applyColorMap((roi_data / 256).astype(np.uint8), self.get_colour_map())
-        _, buffer = cv2.imencode('.png', colour_data)
-        buffer = np.array(buffer)
+            colour_data = cv2.applyColorMap((roi_data / 256).astype(np.uint8), self.get_colour_map())
+            _, buffer = cv2.imencode('.png', colour_data)
+            buffer = np.array(buffer)
 
-        while (not self.image_queue.empty()):
-            self.image_queue.get()
+            while (not self.image_queue.empty()):
+                self.image_queue.get()
 
-        self.image_queue.put(buffer.tobytes())
+            self.image_queue.put(buffer.tobytes())
+        except Exception as e:
+            logging.error(f"Error processing image data, no update: {e}")
 
-        # Fixed quantity of bins instead of generating it from range
-        bins_count = 1024
+        try:
+            # Fixed quantity of bins instead of generating it from range
+            bins_count = 1024
 
-        # Create histogram
-        flat_data = data.flatten()  # Histogram made on original data
-        fig, ax = plt.subplots(figsize=(8,2), dpi=100)
-        ax.hist(flat_data, bins=bins_count, alpha=0.75, color='blue', log=True, histtype='step')
+            # Create histogram
+            flat_data = data.flatten()  # Histogram made on original data
+            fig, ax = plt.subplots(figsize=(8,2), dpi=100)
+            ax.hist(flat_data, bins=bins_count, alpha=0.75, color='blue', log=True, histtype='step')
 
-        # No y-axis
-        ax.yaxis.set_visible(False)
-        for spine in ['top', 'left', 'right']:
-            ax.spines[spine].set_visible(False)
-        # Make x-axis take entire width
-        ax.set_xlim(left=self.clipping['min'], right=self.clipping['max'])
+            # No y-axis
+            ax.yaxis.set_visible(False)
+            for spine in ['top', 'left', 'right']:
+                ax.spines[spine].set_visible(False)
+            # Make x-axis take entire width
+            ax.set_xlim(left=self.clipping['min'], right=self.clipping['max'])
 
-        fig.tight_layout(pad=0.05)
+            fig.tight_layout(pad=0.05)
 
-        # Generate matplotlib figure and convert it to array
-        fig.canvas.draw()
-        histData = np.frombuffer(fig.canvas.renderer.buffer_rgba(), dtype=np.uint8)
-        width, height = fig.canvas.get_width_height()
-        # Resize frombuffer array to 3d
-        histData = histData.reshape((height, width, 4))
-        histData = cv2.cvtColor(histData, cv2.COLOR_RGBA2BGR)
+            # Generate matplotlib figure and convert it to array
+            fig.canvas.draw()
+            histData = np.frombuffer(fig.canvas.renderer.buffer_rgba(), dtype=np.uint8)
+            width, height = fig.canvas.get_width_height()
+            # Resize frombuffer array to 3d
+            histData = histData.reshape((height, width, 4))
+            histData = cv2.cvtColor(histData, cv2.COLOR_RGBA2BGR)
 
-        # Must explicitly close figures
-        plt.close(fig)
+            # Must explicitly close figures
+            plt.close(fig)
 
-        _, histImage = cv2.imencode('.png', histData)
-        while (not self.hist_queue.empty()):
-            self.hist_queue.get()
-        self.hist_queue.put(histImage.tobytes())
-
+            _, histImage = cv2.imencode('.png', histData)
+            while (not self.hist_queue.empty()):
+                self.hist_queue.get()
+            self.hist_queue.put(histImage.tobytes())
+        except Exception as e:
+            logging.error(f"Error when generating histogram: {e}")
     def get_colour_map(self):
         """Get the colour map based on the colour string. Defaults to 'bone' (greyscale)."""
         return getattr(cv2, f'COLORMAP_{self.colour.upper()}', cv2.COLORMAP_BONE)

--- a/control/src/livex/live_data/processor.py
+++ b/control/src/livex/live_data/processor.py
@@ -167,7 +167,7 @@ class LiveDataProcessor():
 
         try:
             # Fixed quantity of bins instead of generating it from range
-            bins_count = 1024
+            bins_count = 2048
 
             # Create histogram
             flat_data = data.flatten()  # Histogram made on original data

--- a/control/src/livex/live_data/processor.py
+++ b/control/src/livex/live_data/processor.py
@@ -136,12 +136,11 @@ class LiveDataProcessor():
         _, buffer = cv2.imencode('.jpg', colour_data)
         buffer = np.array(buffer)
 
-        zipped_data = base64.b64encode(buffer)
-
         while (not self.image_queue.empty()):
             self.image_queue.get()
 
-        self.image_queue.put(zipped_data.decode('utf-8'))
+        # self.image_queue.put(zipped_data.decode('utf-8'))
+        self.image_queue.put(buffer.tobytes())
 
         # Fixed quantity of bins instead of generating it from range
         bins_count = 2048

--- a/control/test/config/livex.cfg
+++ b/control/test/config/livex.cfg
@@ -90,6 +90,9 @@ livedata_endpoint = tcp://192.168.0.33:5020, tcp://192.168.0.32:5020
 endpoint_name = widefov, narrowfov
 # Pixel resolution expressed as WIDTHxHEIGHT
 camera_resolution = 4096x2304, 4096x2304
+camera_pixel_size = 2  # 2 bytes per pixel
+widefov_orientation = up
+narrowfov_orientation = up
 
 
 # Munir adapter odin_data communication

--- a/control/test/static/livex-vite/src/components/cameras/ClickableImage.jsx
+++ b/control/test/static/livex-vite/src/components/cameras/ClickableImage.jsx
@@ -157,7 +157,7 @@ function ClickableImage(props){
         var sendData = coords;
 
         // Adjust to percentages if needed
-        if (valuesAsPercentages) 
+        if (valuesAsPercentages)
         {
           let canvas = document.getElementById(svgId);
           let width = canvas.clientWidth;

--- a/control/test/static/livex-vite/src/components/cameras/ClickableImage.jsx
+++ b/control/test/static/livex-vite/src/components/cameras/ClickableImage.jsx
@@ -185,41 +185,44 @@ function ClickableImage(props){
 
     // Only insert polygon tags if there's enough entries in the array
     return (
-      <div style={{position:'relative', display:'inline-block',
-      width:'100%', height:'auto'}}>
-        <svg
-          id={svgId}
-          onMouseDown={handleMouseDown}
-          onMouseMove={handleMouseMove}
-          onMouseUp={handleMouseUp}
-          onContextMenu={handleContextMenu}
-          style={{position:'absolute',top:0,left:0,width:'100%',height:'100%'}}>
-          {points.length === 4 ?
-            <polygon
-              points={points.map(point => point.join(",")).join(" ")}
-              style={{
-                      pointerEvents:'none', // Unclickable
-                      fill: rectRgbaProperties,
-                      stroke: rectOutlineColour // border
-                    }}
-              />
-            : null
-          }
-        </svg>
+
+      <div>
         {imgData ? (
-          <img
-            id='img'
-            src={imgData}
-            style={{
-            display:'block',
-            width:'100%',
-            height:'auto'
-            }}
-            alt="Live camera feed"
-            />
-        ) : (
-          <div>No Image Available</div>
-        )}
+          <div style={{position:'relative', display:'inline-block',
+          width:'100%', height:'auto'}}>
+            <svg
+              id={svgId}
+              onMouseDown={handleMouseDown}
+              onMouseMove={handleMouseMove}
+              onMouseUp={handleMouseUp}
+              onContextMenu={handleContextMenu}
+              style={{position:'absolute',top:0,left:0,width:'100%',height:'100%'}}>
+              {points.length === 4 ?
+                <polygon
+                  points={points.map(point => point.join(",")).join(" ")}
+                  style={{
+                          pointerEvents:'none', // Unclickable
+                          fill: rectRgbaProperties,
+                          stroke: rectOutlineColour // border
+                        }}
+                  />
+                : null
+              }
+            </svg>
+            <img
+              id='img'
+              src={imgData}
+              style={{
+              display:'block',
+              width:'100%',
+              height:'auto'
+              }}
+              alt="Live camera feed"
+              />
+              </div>
+          ) : (
+            <div>No Image Available</div>
+          )}
       </div>
     );
   };

--- a/control/test/static/livex-vite/src/components/cameras/OrcaCamera.jsx
+++ b/control/test/static/livex-vite/src/components/cameras/OrcaCamera.jsx
@@ -198,7 +198,7 @@ function OrcaCamera(props) {
                   <EndPointDropdownSelector
                     endpoint={liveViewEndPoint}
                     event_type="select"
-                    fullpath="image/colour"
+                    fullpath={`${name}/image/colour`}
                     buttonText={liveViewData?.image?.colour}
                     variant="outline-secondary">
                       {colourEffects.map((effect, index) => (
@@ -241,7 +241,7 @@ function OrcaCamera(props) {
                     <EndPointButton
                       endpoint={liveViewEndPoint}
                       value={dimensions}
-                      fullpath={"image/dimensions"}
+                      fullpath={`${name}/image/dimensions`}
                       event_type="click"
                       variant="outline-primary"
                       className="mb-2">
@@ -257,7 +257,7 @@ function OrcaCamera(props) {
                       </Form.Label>
                       <EndPointSlider
                         endpoint={liveViewEndPoint}
-                        fullpath="image/resolution"
+                        fullpath={`${name}/image/resolution`}
                         min={1}
                         max={100}
                         step={1}>  
@@ -270,7 +270,7 @@ function OrcaCamera(props) {
                     <EndPointDropdownSelector
                       endpoint={liveViewEndPoint}
                       event_type="select"
-                      fullpath="image/resolution"
+                      fullpath={`${name}/image/resolution`}
                       buttonText={liveViewData?.image?.resolution}
                       variant="outline-secondary">
                         {commonImageResolutions.map((effect, index) => (
@@ -288,7 +288,7 @@ function OrcaCamera(props) {
                 <Row className="mt-3">
                   <EndPointDoubleSlider
                     endpoint={liveViewEndPoint}
-                    fullpath="image/clip_range_value"
+                    fullpath={`${name}/image/clip_range_value`}
                     min="0"
                     max="65535"
                     steps="100"
@@ -296,7 +296,7 @@ function OrcaCamera(props) {
                   </EndPointDoubleSlider>
                   <EndPointButton
                     endpoint={liveViewEndPoint}
-                    fullpath={"image/clip_range_value"}
+                    fullpath={`${name}/image/clip_range_value`}
                     event_type="click"
                     value={[0, 65535]}
                     variant="outline-primary">
@@ -306,7 +306,7 @@ function OrcaCamera(props) {
                 <Row className="mt-3">
                   <EndPointButton
                     endpoint={liveViewEndPoint}
-                    fullpath={"image/roi"}
+                    fullpath={`${name}/image/roi`}
                     event_type="click"
                     value={[[0, 100], [0, 100]]}
                     variant="outline-primary">

--- a/control/test/static/livex-vite/src/components/cameras/OrcaCamera.jsx
+++ b/control/test/static/livex-vite/src/components/cameras/OrcaCamera.jsx
@@ -29,7 +29,7 @@ function OrcaCamera(props) {
     let orcaAddress = 'camera/cameras/'+nameString;
     const orcaEndPoint = useAdapterEndpoint(orcaAddress, endpoint_url, 1000);
  
-    const liveViewEndPoint = useAdapterEndpoint('live_data', endpoint_url, 5000);
+    const liveViewEndPoint = useAdapterEndpoint('live_data', endpoint_url, 1000);
     const liveViewData = liveViewEndPoint?.data[name];
 
     // let imgAddress = 'live_data/_image/'+nameString;
@@ -170,7 +170,7 @@ function OrcaCamera(props) {
                   <ClickableImage
                     id={`image-${name}`}
                     endpoint={liveViewEndPoint}
-                    imgPath={`_image/${name}`}
+                    imgPath={`_image/${name}/image`}
                     coordsPath={`${name}/image`}
                     coordsParam="roi"
                     valuesAsPercentages={true}>
@@ -180,9 +180,9 @@ function OrcaCamera(props) {
                   <ClickableImage
                     id={`histogram-${name}`}
                     endpoint={liveViewEndPoint}
-                    imgSrc={liveViewData?.image?.histogram}
-                    fullpath="image"
-                    paramToUpdate="clip_range_percent"
+                    imgPath={`_image/${name}/histogram`}
+                    coordsPath={`${name}/image`}
+                    coordsParam="clip_range_percent"
                     maximiseAxis="y"
                     rectOutlineColour='black'
                     rectRgbaProperties='rgba(50,50,50,0.05)'

--- a/control/test/static/livex-vite/src/components/cameras/OrcaCamera.jsx
+++ b/control/test/static/livex-vite/src/components/cameras/OrcaCamera.jsx
@@ -9,8 +9,9 @@ import DropdownSelector from '../DropdownSelector';
 import Button from 'react-bootstrap/Button';
 import { useState } from 'react';
 import { Dropdown } from 'react-bootstrap';
+import { FloatingLabel } from 'react-bootstrap';
 
-import { checkNullNoDp } from '../../utils';
+import { checkNullNoDp, floatingInputStyle, floatingLabelStyle } from '../../utils';
 
 import ClickableImage from './ClickableImage';
 
@@ -125,29 +126,38 @@ function OrcaCamera(props) {
           }>
             <Col>
               <Row className="mb-3">
-                <Col xs={6}>
-                  <InputGroup>
-                    <InputGroup.Text>Status</InputGroup.Text>
-                    <InputGroup.Text style={{
-                      width: labelWidth,
-                      border: '1px solid lightblue',
-                      backgroundColor: '#e0f7ff'
-                    }}>
-                        {(orcaStatus || "Not found")}
-                    </InputGroup.Text>
-                  </InputGroup>
+                <Col xs={4}>
+                  <FloatingLabel
+                    label="Status">
+                      <Form.Control
+                        plaintext
+                        readOnly
+                        style={floatingLabelStyle}
+                        value={(orcaStatus || "Not found")}
+                      />
+                  </FloatingLabel>
                 </Col>
-                <Col xs={6}>
-                  <InputGroup>
-                    <InputGroup.Text>Frame count</InputGroup.Text>
-                    <InputGroup.Text style={{
-                      width: labelWidth,
-                      border: '1px solid lightblue',
-                      backgroundColor: '#e0f7ff'
-                    }}>
-                        {checkNullNoDp(orcaEndPoint?.data[name]?.status.frame_number)}
-                    </InputGroup.Text>
-                  </InputGroup>
+                <Col xs={4}>
+                  <FloatingLabel
+                    label="Frame Count">
+                      <Form.Control
+                        plaintext
+                        readOnly
+                        style={floatingLabelStyle}
+                        value={checkNullNoDp(orcaEndPoint?.data[name]?.status.frame_number)}
+                      />
+                  </FloatingLabel>
+                </Col>
+                <Col xs={4}>
+                  <FloatingLabel
+                    label="Cam Temp. (C)">
+                      <Form.Control
+                        plaintext
+                        readOnly
+                        style={floatingLabelStyle}
+                        value={checkNullNoDp(orcaEndPoint?.data[name]?.status?.camera_temperature || "Not found")}
+                      />
+                  </FloatingLabel>
                 </Col>
               </Row>
               <Stack>

--- a/control/test/static/livex-vite/src/components/cameras/OrcaCamera.jsx
+++ b/control/test/static/livex-vite/src/components/cameras/OrcaCamera.jsx
@@ -28,10 +28,13 @@ function OrcaCamera(props) {
     const nameString = name.toString();
     let orcaAddress = 'camera/cameras/'+nameString;
     const orcaEndPoint = useAdapterEndpoint(orcaAddress, endpoint_url, 1000);
-
-    let liveViewAddress = 'live_data/liveview/'+nameString;
-    const liveViewEndPoint = useAdapterEndpoint(liveViewAddress, endpoint_url, 1000);
+ 
+    const liveViewEndPoint = useAdapterEndpoint('live_data', endpoint_url, 5000);
     const liveViewData = liveViewEndPoint?.data[name];
+
+    // let imgAddress = 'live_data/_image/'+nameString;
+    // const imgEndPoint = useAdapterEndpoint(imgAddress, endpoint_url, 1000);
+    // const imgData = imgEndPoint?.data;
 
     // Array of camera status names
     const status = ['disconnected', 'connected', 'capturing'];
@@ -167,9 +170,9 @@ function OrcaCamera(props) {
                   <ClickableImage
                     id={`image-${name}`}
                     endpoint={liveViewEndPoint}
-                    imgSrc={liveViewData?.image?.data}
-                    fullpath="image"
-                    paramToUpdate="roi"
+                    imgPath={`_image/${name}`}
+                    coordsPath={`${name}/image`}
+                    coordsParam="roi"
                     valuesAsPercentages={true}>
                   </ClickableImage>
                   </Row>

--- a/control/test/static/livex-vite/src/components/cameras/OrcaCamera.jsx
+++ b/control/test/static/livex-vite/src/components/cameras/OrcaCamera.jsx
@@ -243,7 +243,7 @@ function OrcaCamera(props) {
                           style={floatingInputStyle}>
                             {colourEffects.map(
                               (effect, index) => (
-                                <option value={index} key={index}>
+                                <option value={effect} key={index}>
                                   {effect}
                                 </option>
                             ))}
@@ -259,7 +259,7 @@ function OrcaCamera(props) {
                           buttonText={liveViewData?.image?.resolution}
                           style={floatingInputStyle}>
                             {commonImageResolutions.map((effect, index) => (
-                              <option value={index} key={index}>
+                              <option value={effect} key={index}>
                                 {effect}
                               </option>
                               ))

--- a/control/test/static/livex-vite/src/components/cameras/OrcaCamera.jsx
+++ b/control/test/static/livex-vite/src/components/cameras/OrcaCamera.jsx
@@ -20,6 +20,7 @@ const EndPointButton = WithEndpoint(Button);
 const EndPointDropdownSelector = WithEndpoint(DropdownSelector);
 const EndPointDoubleSlider = WithEndpoint(OdinDoubleSlider);
 const EndPointSlider = WithEndpoint(Form.Range);
+const EndPointSelect = WithEndpoint(Form.Select);
 
 function OrcaCamera(props) {
     const {endpoint_url} = props;
@@ -199,132 +200,64 @@ function OrcaCamera(props) {
                     valuesAsPercentages={true}>
                   </ClickableImage>
                 </Row>
-                <Col>
-                <Form>
-                <InputGroup className="mt-3">
-                  <InputGroup.Text>
-                    Image Colour Map
-                  </InputGroup.Text>
-                  <EndPointDropdownSelector
-                    endpoint={liveViewEndPoint}
-                    event_type="select"
-                    fullpath={`${name}/image/colour`}
-                    buttonText={liveViewData?.image?.colour}
-                    variant="outline-secondary">
-                      {colourEffects.map((effect, index) => (
-                        <Dropdown.Item
-                          key={index}
-                          eventKey={effect}>
-                            {effect}
-                          </Dropdown.Item>
-                      ))}
-                  </EndPointDropdownSelector>
-                </InputGroup>
-
-                <Row>
-                  <Col xs="6">
-                    <InputGroup>
-                      <InputGroup.Text>
-                        Image Width
-                      </InputGroup.Text>
-                      <Form.Control
-                        type="number"
-                        placeholder={liveViewData?.image.size_x || "Width"}
-                        value={width}
-                        onChange={widthChange}
-                      />
-                    </InputGroup>
-
-                    <InputGroup>
-                        <InputGroup.Text>
-                            Image Height
-                        </InputGroup.Text>
-                        <Form.Control
-                          type="number"
-                          placeholder={liveViewData?.image.size_y || "Height"}
-                          value={height}
-                          onChange={heightChange}
-                        />
-                    </InputGroup>
-                  </Col>
-                  <Col xs="6" className="mt-3">
+                <Row className="mt-3">
+                  <Col xs={12} sm={6} style={{alignItems: 'center', justifyContent: 'center', display:'flex'}}>
                     <EndPointButton
                       endpoint={liveViewEndPoint}
-                      value={dimensions}
-                      fullpath={`${name}/image/dimensions`}
+                      fullpath={`${name}/image/clip_range_value`}
                       event_type="click"
-                      variant="outline-primary"
-                      className="mb-2">
-                        Update image dimensions
+                      value={[0, 65535]}
+                      variant="primary">
+                      Reset Clipping Range to 100%
+                    </EndPointButton>
+                  </Col>
+                  <Col xs={12} sm={6}  style={{alignItems: 'center', justifyContent: 'center', display:'flex'}}>
+                    <EndPointButton
+                      endpoint={liveViewEndPoint}
+                      fullpath={`${name}/image/roi`}
+                      event_type="click"
+                      value={[[0, 100], [0, 100]]}
+                      variant="primary">
+                        Reset Region of Interest to Full Image
                     </EndPointButton>
                   </Col>
                 </Row>
                 <Row className="mt-3">
-                  <Col xs={12} md={8}>
-                    <Form>
-                      <Form.Label>
-                        Resolution. Current: {liveViewData?.image?.resolution}
-                      </Form.Label>
-                      <EndPointSlider
-                        endpoint={liveViewEndPoint}
-                        fullpath={`${name}/image/resolution`}
-                        min={1}
-                        max={100}
-                        step={1}>  
-                      </EndPointSlider>
-                    </Form>
+                  <Col xs={6}>
+                    <FloatingLabel
+                      label="Image Colour Map">
+                        <EndPointSelect
+                          endpoint={liveViewEndPoint}
+                          fullpath={`${name}/image/colour`}
+                          buttonText={liveViewData?.image?.colour}
+                          style={floatingInputStyle}>
+                            {colourEffects.map(
+                              (effect, index) => (
+                                <option value={index} key={index}>
+                                  {effect}
+                                </option>
+                            ))}
+                          </EndPointSelect>
+                    </FloatingLabel>
                   </Col>
-                  <Col md={4}>
-                  <InputGroup className="mt-3">
-                    <InputGroup.Text>Common Res (%)</InputGroup.Text>
-                    <EndPointDropdownSelector
-                      endpoint={liveViewEndPoint}
-                      event_type="select"
-                      fullpath={`${name}/image/resolution`}
-                      buttonText={liveViewData?.image?.resolution}
-                      variant="outline-secondary">
-                        {commonImageResolutions.map((effect, index) => (
-                          <Dropdown.Item
-                            key={index}
-                            eventKey={effect}>
-                              {effect}
-                          </Dropdown.Item>
-                        ))}
-                      </EndPointDropdownSelector>
-                    </InputGroup>
+                  <Col xs={6}>
+                    <FloatingLabel
+                      label="Resolution (%)">
+                        <EndPointSelect
+                          endpoint={liveViewEndPoint}
+                          fullpath={`${name}/image/resolution`}
+                          buttonText={liveViewData?.image?.resolution}
+                          style={floatingInputStyle}>
+                            {commonImageResolutions.map((effect, index) => (
+                              <option value={index} key={index}>
+                                {effect}
+                              </option>
+                              ))
+                            }
+                        </EndPointSelect>
+                    </FloatingLabel>
                   </Col>
                 </Row>
-
-                <Row className="mt-3">
-                  <EndPointDoubleSlider
-                    endpoint={liveViewEndPoint}
-                    fullpath={`${name}/image/clip_range_value`}
-                    min="0"
-                    max="65535"
-                    steps="100"
-                    title="Clipping range">
-                  </EndPointDoubleSlider>
-                  <EndPointButton
-                    endpoint={liveViewEndPoint}
-                    fullpath={`${name}/image/clip_range_value`}
-                    event_type="click"
-                    value={[0, 65535]}
-                    variant="outline-primary">
-                    Reset Clipping Range to 100%
-                  </EndPointButton>
-                </Row>
-                <Row className="mt-3">
-                  <EndPointButton
-                    endpoint={liveViewEndPoint}
-                    fullpath={`${name}/image/roi`}
-                    event_type="click"
-                    value={[[0, 100], [0, 100]]}
-                    variant="outline-primary">
-                      Reset Region of Interest to Full Image
-                  </EndPointButton>
-                </Row>
-                </Form>
-                </Col>
               </TitleCard>
             </Col>
           </TitleCard>

--- a/control/test/static/livex-vite/src/components/cameras/OrcaCamera.jsx
+++ b/control/test/static/livex-vite/src/components/cameras/OrcaCamera.jsx
@@ -201,7 +201,12 @@ function OrcaCamera(props) {
                   </ClickableImage>
                 </Row>
                 <Row className="mt-3">
-                  <Col xs={12} sm={6} style={{alignItems: 'center', justifyContent: 'center', display:'flex'}}>
+                  <Col xs={12} sm={6} 
+                    style={{
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      display:'flex'
+                    }}>
                     <EndPointButton
                       endpoint={liveViewEndPoint}
                       fullpath={`${name}/image/clip_range_value`}
@@ -211,7 +216,12 @@ function OrcaCamera(props) {
                       Reset Clipping Range to 100%
                     </EndPointButton>
                   </Col>
-                  <Col xs={12} sm={6}  style={{alignItems: 'center', justifyContent: 'center', display:'flex'}}>
+                  <Col xs={12} sm={6} 
+                    style={{
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      display:'flex'
+                    }}>
                     <EndPointButton
                       endpoint={liveViewEndPoint}
                       fullpath={`${name}/image/roi`}

--- a/control/test/static/livex-vite/src/components/cameras/OrcaCamera.jsx
+++ b/control/test/static/livex-vite/src/components/cameras/OrcaCamera.jsx
@@ -150,21 +150,6 @@ function OrcaCamera(props) {
               <Stack>
               <InputGroup>
                 <InputGroup.Text>
-                  command
-                </InputGroup.Text>
-                <EndPointFormControl
-                  endpoint={orcaEndPoint}
-                  type="text"
-                  fullpath="command"
-                  event_type="enter"
-                  disabled={connectedPuttingDisable}>
-                </EndPointFormControl>
-              </InputGroup>
-              </Stack>
-
-              <Stack>
-              <InputGroup>
-                <InputGroup.Text>
                     exposure_time
                 </InputGroup.Text>
                 <EndPointFormControl


### PR DESCRIPTION
Changes to the camera UI from ESRF feedback.

## Issues Approached
- Closes #49, this is the target issue and each of the points within it have been addressed.

## Changes Made

+ Display of camera temperature in UI as reported by camera status
~ Exposure time input no longer disappears when you enter a value
+ Adds rotation of camera images based on an up/down/left/right value in config, indicating which of those directions is 'up'.
+ You can right-click to cancel a selection on the ClickableImage. If you have no selection, this brings up the context menu as normal
+ Histogramming works as it did on the beamtime and this seems acceptable
~ Histogram type changed to 'steps' as it's much more performant and allows use of system even on slower systems
+ Image processor try/catches errors instead of falling over
~ Many options removed from camera UI - clipping is done only via histogram, resolution is just the 10/25/50/75/100 dropdown, and the reset buttons have their style changed and moved up to be more obvious.