### PR TITLE
47 furnace UI thermocouples

### DIFF
--- a/firmware/livex/src/taskPid.cpp
+++ b/firmware/livex/src/taskPid.cpp
@@ -32,18 +32,18 @@ void Core0PIDTask(void * pvParameters)
       xSemaphoreTake(gradientAspcMutex, portMAX_DELAY);
       // Read A
       int idx = modbus_server.combineHoldingRegisters(MOD_HEATERTC_A_IDX_HOLD);
-      float result = mcp[idx].readThermocouple();
       if (0<=idx && idx<num_mcp)
       {
+        float result = mcp[idx].readThermocouple();
         PID_A.input = result;
         modbus_server.floatToInputRegisters(MOD_HEATERTC_A_INP, PID_A.input);
       }
 
       // Read B
       idx = modbus_server.combineHoldingRegisters(MOD_HEATERTC_B_IDX_HOLD);
-      result = mcp[idx].readThermocouple();
       if (0<=idx && idx<num_mcp)
       {
+        float result = mcp[idx].readThermocouple();
         PID_B.input = result;
         modbus_server.floatToInputRegisters(MOD_HEATERTC_B_INP, PID_B.input);
       }
@@ -58,7 +58,7 @@ void Core0PIDTask(void * pvParameters)
           idx = modbus_server.combineHoldingRegisters(MOD_EXTRATC_A_IDX_HOLD + (i-2)*2);
           if (0<=idx && idx<num_mcp)
           {
-            result = mcp[idx].readThermocouple();
+            float result = mcp[idx].readThermocouple();
             modbus_server.floatToInputRegisters(MOD_EXTRATC_A_INP+(i*2), result);
           }
         }


### PR DESCRIPTION
This change slipped through the cracks. The only commit here is changing the frequency at which thermocouples are read - heaters A and B are every interrupt as normal, but the 'extra' thermocouples are 1/s instead.

## Issues Approached

#47 This was supposed to be closed by #60 but this covers the last changes made as a result of it.

## Changes Made

+ 'Extra' thermocouples now read 1/s instead of every interrupt. This will prevent slowdown at high frequencies.