### PR TITLE
62 firmware test fixes

### DIFF
--- a/control/src/livex/furnace/controls/thermocoupleManager.py
+++ b/control/src/livex/furnace/controls/thermocoupleManager.py
@@ -74,7 +74,6 @@ class ThermocoupleManager:
         for tc in self.thermocouples:
             index = tc.connection.value
             write_modbus_float(self.client, index, tc.addr)
-            logging.warning(f"Wrote {index} to addr {tc.addr}")
             tc.index = index
 
         write_coil(self.client, modAddr.tc_type_update_coil, 1)

--- a/control/src/livex/inference/inference_endpoint.py
+++ b/control/src/livex/inference/inference_endpoint.py
@@ -53,8 +53,6 @@ class InferenceEndpoint():
                     self.results[key], None
                 )  # Function uses key (the parameter) as argument via partial
 
-            logging.warning(f"\nresults tree: {results_tree}\n")
-
             results_tree = ParameterTree(results_tree)
             self.tree['results'] = results_tree
 

--- a/control/test/config/livex.cfg
+++ b/control/test/config/livex.cfg
@@ -53,9 +53,8 @@ kd_default = 0.1
 # index refers to order they are connected on hardware: 0x60, 0x67->0x63.
 # first two must be enabled for use as these correspond to heaters A and B
 # refer to furnace PLC box for what label correspons to which address
-thermocouple_indices = 0,1,2,3,4,5
-upper_heater_tc = e
-lower_heater_tc = f
+upper_heater_tc = a
+lower_heater_tc = b
 extra_tcs = c,d
 extra_tc_names = outside, inside
 

--- a/control/test/static/livex-vite/src/components/cameras/OrcaCamera.jsx
+++ b/control/test/static/livex-vite/src/components/cameras/OrcaCamera.jsx
@@ -204,35 +204,36 @@ function OrcaCamera(props) {
                   <Col xs={6}>
                     <FloatingLabel
                       label="Image Colour Map">
-                        <EndPointSelect
-                          endpoint={liveViewEndPoint}
-                          fullpath={`${name}/image/colour`}
-                          buttonText={liveViewData?.image?.colour}
-                          style={floatingInputStyle}>
-                            {colourEffects.map(
-                              (effect, index) => (
-                                <option value={effect} key={index}>
-                                  {effect}
-                                </option>
-                            ))}
-                          </EndPointSelect>
+                      <Form.Select
+                        style={floatingInputStyle}
+                        value={liveViewData?.image?.colour.value ?? "?"}
+                        onChange={(e)=> {
+                          liveViewEndPoint.put(e.target.value, `${name}/image/colour`);
+                        }}>
+                          {colourEffects.map((effect, index) => (
+                            <option value={effect} key={index}>
+                              {effect}
+                            </option>
+                          ))}
+                      </Form.Select>
                     </FloatingLabel>
                   </Col>
                   <Col xs={6}>
                     <FloatingLabel
                       label="Resolution (%)">
-                        <EndPointSelect
-                          endpoint={liveViewEndPoint}
-                          fullpath={`${name}/image/resolution`}
-                          buttonText={liveViewData?.image?.resolution}
-                          style={floatingInputStyle}>
+                        <Form.Select
+                          style={floatingInputStyle}
+                          value={liveViewData?.image?.resolution.value}
+                          onChange={(e)=> {
+                            liveViewEndPoint.put(e.target.value, `${name}/image/resolution`);
+                          }}>
                             {commonImageResolutions.map((effect, index) => (
                               <option value={effect} key={index}>
                                 {effect}
                               </option>
                               ))
                             }
-                        </EndPointSelect>
+                        </Form.Select>
                     </FloatingLabel>
                   </Col>
                 </Row>

--- a/control/test/static/livex-vite/src/components/motors/KdcController.jsx
+++ b/control/test/static/livex-vite/src/components/motors/KdcController.jsx
@@ -23,8 +23,9 @@ function KdcController(props) {
           <EndPointButton
             endpoint={kinesisEndPoint}
             value={true}
-            fullpath="status/reconnect"
-            variant={kinesisEndPoint.data?.controllers[name].connected ? "primary" : "danger"}>
+            fullpath={`controllers/${name}/connected`}
+            variant={kinesisEndPoint.data?.controllers[name].connected ? "primary" : "danger"}
+            disabled={kinesisEndPoint.data?.controllers[name].connected}>
             {kinesisEndPoint.data?.controllers[name].connected ? 'Connected' : 'Reconnect'}
           </EndPointButton>
         </Col>


### PR DESCRIPTION
This should fix the issues referenced in the issue: motor reconnect buttons, thermocouple manager addressing, and colour map label updates.

## Issues Approached

Closes #62

## Changes made

+ Thermocouple manager does not base its calculations for addresses of the enumeration it's iterating over; instead, Thermocouple objects get an address assigned and we iterate over the TCs instead.
~ Camera EndPointForm.Selects didn't seem to work, these have been made into something more basic but visually identical
~ Motor reconnect button pointed at the wrong place. This should resolve that