### PR TITLE
87 88 metadata setup

### DIFF
--- a/control/src/livex/acquisition/controller.py
+++ b/control/src/livex/acquisition/controller.py
@@ -337,6 +337,10 @@ class LiveXController(BaseController):
             iac_set(self.metadata, 'fields/furnace_framerate', 'value',
                 self.trigger_manager.frequencies['furnace'])
 
+            iac_set(self.metadata, 'fields/was_thermal_gradient_active', 'value', self.furnace.gradient.was_gradient_active)
+            # Reset the flag
+            self.furnace.gradient.was_gradient_active = False
+
         # Cams stop capturing, num-frames to 0, start again
         # Move camera(s) to capture state
         for camera in self.orca.cameras:

--- a/control/src/livex/acquisition/controller.py
+++ b/control/src/livex/acquisition/controller.py
@@ -25,7 +25,7 @@ class LiveXController(BaseController):
         # Parse options
         self.ref_trigger = options.get('reference_trigger', 'furnace')
         # Filepaths can vary by system - i.e. cameras may have multiple storage locations
-        self.furnace_filepath = options.get('furnace_filepath', '/tmp')
+        self.local_filepath = options.get('local_filepath', '/tmp')
         self.widefov_filepath = options.get('widefov_filepath', '/tmp')
         self.narrowfov_filepath = options.get('narrowfov_filepath', '/tmp')
 
@@ -42,15 +42,15 @@ class LiveXController(BaseController):
         self.filepaths = {
             'furnace': {
                 'filename': None,
-                'filepath': None
+                'filepath': self.local_filepath
             },
             'metadata': {
                 'filename': None,
-                'filepath': self.furnace_filepath
+                'filepath': self.local_filepath
             }
         }
 
-        self.furnace_filepath = "."
+        # self.local_filepath = "."
 
     def initialize(self, adapters):
         """Initialize the controller.
@@ -114,7 +114,7 @@ class LiveXController(BaseController):
 
             # Add cameras to self.filepaths for acquisition handling with default
             for camera in self.orca.cameras:
-                self.filepaths[camera.name] = {'filename': None, 'filepath': self.furnace_filepath}
+                self.filepaths[camera.name] = {'filename': None, 'filepath': self.local_filepath}
 
                 # Set cameras to trigger source 2 (external)
                 # Internal triggering of 120Hz is much too fast for inferencing
@@ -211,18 +211,18 @@ class LiveXController(BaseController):
         # Furnace
         filename = build_filename('furnace', 'h5')
         self.filepaths['furnace']['filename'] = filename
-        self.filepaths['furnace']['filepath'] = self.furnace_filepath
+        self.filepaths['furnace']['filepath'] = self.local_filepath + "/furnace"
 
         # Metadata
         filename = build_filename('metadata', 'yaml')
         self.filepaths['metadata']['filename'] = filename
-        self.filepaths['metadata']['filepath'] = self.furnace_filepath
+        self.filepaths['metadata']['filepath'] = self.local_filepath + "/metadata"
 
         # Cameras
         for camera in self.orca.cameras:
             name = camera.name
             self.filepaths[name]["filename"] = f"{experiment_id}_{name}"
-            self.filepaths[name]["filepath"] = self.options.get(f"{name}_filepath", self.furnace_filepath)
+            self.filepaths[name]["filepath"] = self.options.get(f"{name}_filepath", self.local_filepath)
         # Set values in metadata adapter
         iac_set(self.metadata, 'fields/experiment_id', 'value', experiment_id)
         iac_set(self.metadata, 'yaml', 'file', self.filepaths['metadata']['filename'])

--- a/control/src/livex/furnace/controller.py
+++ b/control/src/livex/furnace/controller.py
@@ -268,6 +268,11 @@ class FurnaceController():
         self.file_writer.open_file()
         self.file_open_flag = True
 
+        # If you are starting the acquisition and the gradient is on, was_gradient_active should be
+        # true for the benefit of the metadata
+        if self.gradient.enable:
+            self.gradient.was_gradient_active = True
+
         self.acquiring = True
 
     def _stop_acquisition(self):

--- a/control/src/livex/furnace/controls/gradient.py
+++ b/control/src/livex/furnace/controls/gradient.py
@@ -56,7 +56,6 @@ class Gradient():
         if value:
             write_coil(self.client, self.addresses['enable'], 1)
             if self.furnace_controller.acquiring:
-                logging.warning(f"gradient enabled, setting was_gradient_active to true")
                 self.was_gradient_active = True
         else:
             write_coil(self.client, self.addresses['enable'], 0)

--- a/control/src/livex/furnace/controls/gradient.py
+++ b/control/src/livex/furnace/controls/gradient.py
@@ -18,6 +18,8 @@ class Gradient():
         self.theoretical  = 0
         self.high         = 'Upper'
 
+        self.was_gradient_active = False
+
         self.furnace_controller = furnace_controller
 
         self.tree = ParameterTree({
@@ -53,6 +55,9 @@ class Gradient():
         """Set the enable value for the thermal gradient."""
         if value:
             write_coil(self.client, self.addresses['enable'], 1)
+            if self.furnace_controller.acquiring:
+                logging.warning(f"gradient enabled, setting was_gradient_active to true")
+                self.was_gradient_active = True
         else:
             write_coil(self.client, self.addresses['enable'], 0)
 

--- a/control/test/config/livex.cfg
+++ b/control/test/config/livex.cfg
@@ -1,7 +1,7 @@
 [server]
 debug_mode  = 1
 http_port   = 8888
-http_addr   = 
+http_addr   = 192.168.0.6
 static_path = test/static
 # For use with no cameras, disable camera, live_data, munir, and livex
 adapters    = furnace, trigger, graph, metadata, livex, camera, live_data, munir, sequencer, kinesis, inference
@@ -18,9 +18,9 @@ module = livex.acquisition.adapter.LiveXAdapter
 # Other triggers derived their frame targets from this one. Must match a trigger adapter name
 # For LiveX specifically, this needs to be the furnace for correct operation. But it can be renamed
 reference_trigger = furnace
-# Filepaths should match system names. Furnace (includes metadata), and camera names
-# Furnace filepath is treated as default
-furnace_filepath = /tmp
+# Filepaths past local should use the system name, such as widefov_filepath, narrowfov_filepath
+# local filepath is treated as default and used for furnace and metadata
+local_filepath = /tmp
 widefov_filepath = /data
 narrowfov_filepath = /data2
 
@@ -69,10 +69,10 @@ power_output_scale = 1
 # index refers to order they are connected on hardware: 0x60, 0x67->0x63.
 # first two must be enabled for use as these correspond to heaters A and B
 # refer to furnace PLC box for what label correspons to which address
-upper_heater_tc = a
-lower_heater_tc = b
-extra_tcs = c,d
-extra_tc_names = outside, inside
+upper_heater_tc = c
+lower_heater_tc = d
+extra_tcs = e
+extra_tc_names = extra
 
 # Include ALL information sent via TCP in saved data, which includes additional PID information
 pid_debug = 0
@@ -128,8 +128,8 @@ module = munir.adapter.MunirAdapter
 fp_mode = 1
 subsystems = 
 # widefov, narrowfov
-widefov_endpoints = tcp://192.168.0.33:5000
-narrowfov_endpoints = tcp://192.168.0.32:5000
+widefov_endpoints = 
+narrowfov_endpoints = 
 odin_data_config_path = test/config
 # Comms timeout
 ctrl_timeout = 1.0
@@ -143,7 +143,7 @@ liveview_control = 0
 module = orca_quest.adapter.OrcaAdapter
 # Connections are defined by endpoint and given names as reference.
 # To remove a connection, remove the endpoint. Give each a name. Excess names are not used.
-camera_endpoint = tcp://192.168.0.33:9001, tcp://192.168.0.32:9001
+camera_endpoint = 
 camera_name = widefov, narrowfov
 
 status_bg_task_enable = 1
@@ -181,7 +181,7 @@ module = livex.inference.adapter.InferenceAdapter
 
 # Names should match the expected internal name of the system, e.g. narrowfov, widefov
 # Results from endpoint use this name
-endpoint_addresses=tcp://192.168.0.32:9002
+endpoint_addresses=
 names=narrowfov
 bg_poll_task_enable = 1
 bg_poll_task_interval = 1

--- a/control/test/config/metadata.json
+++ b/control/test/config/metadata.json
@@ -161,6 +161,12 @@
         "persist": true,
         "user_input": true
     },
+    "scintillator": {
+        "label": "Scintillator type",
+        "default": "",
+        "persist": true,
+        "user_input": true
+    },
     "sequence_id": {
         "label": "Controlling sequence execution ID",
         "default": 1,

--- a/control/test/config/metadata.json
+++ b/control/test/config/metadata.json
@@ -65,9 +65,9 @@
         "persist": true,
         "user_input": false
     },
-    "thermal_gradient": {
+    "was_thermal_gradient_active": {
         "label": "Thermal Gradient",
-        "default": 0.0,
+        "default": false,
         "persist": false,
         "user_input": false
     },

--- a/control/test/static/livex-vite/src/components/setup/Metadata.jsx
+++ b/control/test/static/livex-vite/src/components/setup/Metadata.jsx
@@ -17,7 +17,7 @@ function Metadata(props) {
 
     const {endpoint_url} = props;
 
-    const metadataEndPoint = useAdapterEndpoint('metadata', endpoint_url, 5000);
+    const metadataEndPoint = useAdapterEndpoint('metadata', endpoint_url, 1000);
     // Need some object defined even when metadataEndPoint is resolving to null
     const metaJson = metadataEndPoint?.data?.fields ? metadataEndPoint.data.fields : {} ;
 

--- a/control/test/static/livex-vite/src/components/setup/Trigger.jsx
+++ b/control/test/static/livex-vite/src/components/setup/Trigger.jsx
@@ -241,7 +241,7 @@ function Trigger(props) {
                     border: '1px solid lightblue',
                     backgroundColor: '#e0f7ff'
                   }}>
-                    {checkNullNoDp(furnaceEndPoint.data.tcp?.tcp_reading?.counter)}
+                    {checkNullNoDp(furnaceEndPoint.data.tcp?.tcp_reading?.frame)}
                   </InputGroup.Text>
                 </InputGroup>
               </Col>
@@ -253,7 +253,19 @@ function Trigger(props) {
                     border: '1px solid lightblue',
                     backgroundColor: '#e0f7ff'
                   }}>
-                    {checkNullNoDp(orcaEndPoint?.data?.cameras?.widefov.status.frame_number)}
+                    {checkNullNoDp(orcaEndPoint?.data?.widefov?.status?.frame_number)}
+                  </InputGroup.Text>
+                </InputGroup>
+              </Col>
+              <Col>
+                <InputGroup>
+                  <InputGroup.Text>narrowfov frame count</InputGroup.Text>
+                  <InputGroup.Text style={{
+                    width: labelWidth,
+                    border: '1px solid lightblue',
+                    backgroundColor: '#e0f7ff'
+                  }}>
+                    {checkNullNoDp(orcaEndPoint?.data?.narrowfov?.status?.frame_number)}
                   </InputGroup.Text>
                 </InputGroup>
               </Col>


### PR DESCRIPTION
This branch closes #87  and closes #88, addressing all of the points raised within those issues.

- (88) Frame counters now report and also narrowfov is included on that page for completeness
- (87) Scintillator metadata type added
- (87) Metadata endpoint refresh rate 1s to avoid annoying delay where it wouldn't appear
- (87) Furnace and metadata filepaths now point to /furnace and /metadata from wherever 'local_filepath' is set in config  
- (87) Thermal gradient metadata is now a flag 'was_gradient_active'. if you're doing an acquisition and **enable** the gradient, this will be set to true. if you start an acquisition and the gradient is enabled, this is also set to true immediately.