### PR TITLE
84 sequencer logging notes

### DIFF
--- a/control/src/livex/acquisition/controller.py
+++ b/control/src/livex/acquisition/controller.py
@@ -131,7 +131,8 @@ class LiveXController(BaseController):
 
         # Make filename
         self.sequence_id = iac_get(self.metadata, 'fields/sequence_id/value', param='value')
-        iac_set(self.metadata, 'fields/sequence_id', 'value', self.sequence_id+1)
+        self.sequence_id = self.sequence_id + 1
+        iac_set(self.metadata, 'fields/sequence_id', 'value', self.sequence_id)
         iac_set(self.metadata, 'fields/sequence_name', 'value', sequence_name)
 
         padded_seq_id = str(self.sequence_id).rjust(4, '0')
@@ -306,11 +307,11 @@ class LiveXController(BaseController):
 
         if self.executing_sequence:
             iac_set(self.metadata, 'fields/sequence_id', 'value', self.sequence_id)
-
             self.log_sequence_message(f"Beginning acquisition {acq_num}.")
         else:  # No sequence currently
             iac_set(self.metadata, 'fields/sequence_name', 'value', 'None')
-            iac_set(self.metadata, 'fields/sequence_id', 'value', -1)
+            # Don't update sequence_id here - preserve the counter for next sequence
+            # The acquisition YAML will show -1 via stop_acquisition logic
 
         # Enable timer coils simultaneously
         self.trigger.set_all_timers(

--- a/control/src/livex/furnace/controller.py
+++ b/control/src/livex/furnace/controller.py
@@ -370,7 +370,7 @@ class FurnaceController():
             return
         frame = self.packet_decoder.data['frame']
         # Values are strings as you cannot have multiple data types in one field
-        self.event_buffer.append({'event_frame': frame, 'event_key': key, 'event_value': str(value)})
+        self.event_buffer.append({'event_frame': str(frame), 'event_key': key, 'event_value': str(value)})
 
     @run_on_executor
     def background_stream_task(self):
@@ -378,83 +378,86 @@ class FurnaceController():
         in the parameter tree.
         """
         while self.bg_stream_task_enable:
-            if self.mocking:
-                if self.acquiring:
-                    try:
-                        frame, temp = self.tcp_client.recv(self.packet_decoder.size)
-
-                        logging.debug(f"Mock acquisition data: temperature {temp} at reading {frame}")
-                    except Exception as e:
-                        logging.debug(f"Mock acquisition error: {e}")
-
-                    # Do not need to go as fast for a fake acquisition, there is no timeout
-                time.sleep(1/self.pid_frequency)
-
-            else:
-                if self.acquiring:
-                    try:
-                        reading = self.tcp_client.recv(self.packet_decoder.size)
+            if self.acquiring:
+                try:
+                    reading = self.tcp_client.recv(self.packet_decoder.size)
+                    
+                    # Decode the reading using packet decoder
+                    self.tcp_reading = self.packet_decoder.unpack(reading)
+                    
+                    if not self.mocking:
                         logging.debug(self.packet_decoder.data['frame'])
-                        self.tcp_reading = self.packet_decoder.unpack(reading)
+                    else:
+                        logging.debug(f"Mock acquisition data: frame {self.packet_decoder.data['frame']}, temperature_upper {self.packet_decoder.data['temperature_upper']}")
 
-                    except socket.timeout:
+                except socket.timeout:
+                    if not self.mocking:
                         logging.debug("TCP Socket timeout: read no data")
                         continue  # If no data received, do not use the packet_decoding logic
-                    except Exception as e:
+                    else:
+                        logging.debug("Mock TCP timeout (expected for mock)")
+                except Exception as e:
+                    if not self.mocking:
                         logging.debug(f"Other TCP error: {str(e)}")
                         logging.debug("Halting background tasks")
                         self._stop_background_tasks()
                         break
+                    else:
+                        logging.debug(f"Mock TCP error: {e}")
 
-                    self.tcp_reading = self.packet_decoder.data
+                self.tcp_reading = self.packet_decoder.data
 
-                    # Add decoded data to the stream buffer
-                    for attr in self.packet_decoder.data.keys():
-                        self.stream_buffer[attr].append(self.packet_decoder.data[attr])
+                # Add decoded data to the stream buffer
+                for attr in self.packet_decoder.data.keys():
+                    self.stream_buffer[attr].append(self.packet_decoder.data[attr])
 
-                    # After a certain number of data reads, write data to the file
-                    if len(self.stream_buffer['frame']) >= self.pid_frequency:
-                        self.file_writer.write_hdf5(
-                            data=self.stream_buffer,
-                            groupname=self.data_groupname
-                        )
-                        # Then clear the stream buffer
-                        for key in self.stream_buffer:
-                            self.stream_buffer[key].clear()
+                # After a certain number of data reads, write data to the file
+                if len(self.stream_buffer['frame']) >= self.pid_frequency:
+                    self.file_writer.write_hdf5(
+                        data=self.stream_buffer,
+                        groupname=self.data_groupname
+                    )
+                    # Then clear the stream buffer
+                    for key in self.stream_buffer:
+                        self.stream_buffer[key].clear()
 
-                        # Additional information written at a lower frequency
-                        secondary_data = {
-                            'frame': [self.packet_decoder.data['frame']],
-                            'setpoint_upper': [self.pid_upper.setpoint],
-                            'setpoint_lower': [self.pid_lower.setpoint],
-                            'output_upper': [self.pid_upper.output],
-                            'output_lower': [self.pid_lower.output]
+                    # Additional information written at a lower frequency
+                    secondary_data = {
+                        'frame': [self.packet_decoder.data['frame']],
+                        'setpoint_upper': [self.pid_upper.setpoint],
+                        'setpoint_lower': [self.pid_lower.setpoint],
+                        'output_upper': [self.pid_upper.output],
+                        'output_lower': [self.pid_lower.output]
+                    }
+                    # Include additional thermocouples if enabled, not including a or b (0,1)
+                    for tc in self.tc_manager.thermocouples[2:self.tc_manager.num_mcp]:
+                        if tc.index is not None and tc.index >= 0:
+                            data_label = f'thermocouple_{tc.label}'
+                            secondary_data[data_label] = [tc.value]
+
+                    self.file_writer.write_hdf5(
+                        data=secondary_data,
+                        groupname="slow_data"
+                    )
+
+                    # Write out the event buffer once per second too
+                    # List-of-dicts format won't work, so convert it to dict-of-lists
+                    if self.event_buffer:
+                        batch = {
+                            "event_frame": [e["event_frame"] for e in self.event_buffer],
+                            "event_key":   [e["event_key"]   for e in self.event_buffer],
+                            "event_value": [e["event_value"] for e in self.event_buffer]
                         }
-                        # Include additional thermocouples if enabled, not including a or b (0,1)
-                        for tc in self.tc_manager.thermocouples[2:self.tc_manager.num_mcp]:
-                            if tc.index is not None and tc.index >= 0:
-                                data_label = f'thermocouple_{tc.label}'
-                                secondary_data[data_label] = [tc.value]
-
                         self.file_writer.write_hdf5(
-                            data=secondary_data,
-                            groupname="slow_data"
+                            data=batch,
+                            groupname="event_data"
                         )
+                        self.event_buffer.clear()
 
-                        # Write out the event buffer once per second too
-                        # List-of-dicts format won't work, so convert it to dict-of-lists
-                        if self.event_buffer:
-                            batch = {
-                                "event_frame": [e["event_frame"] for e in self.event_buffer],
-                                "event_key":   [e["event_key"]   for e in self.event_buffer],
-                                "event_value": [e["event_value"] for e in self.event_buffer]
-                            }
-                            self.file_writer.write_hdf5(
-                                data=batch,
-                                groupname="event_data"
-                            )
-                            self.event_buffer.clear()
-
+            # Sleep interval - shorter for mocking to avoid it going too fast
+            if self.mocking:
+                time.sleep(1/self.pid_frequency)
+            else:
                 time.sleep(self.bg_stream_task_interval)
 
     @run_on_executor

--- a/control/src/livex/furnace/controller.py
+++ b/control/src/livex/furnace/controller.py
@@ -86,7 +86,7 @@ class FurnaceController():
         self.background_thread_counter = 0
 
         self.file_writer = FileWriter(self.log_directory, self.log_filename, 
-            dtypes={'timestamps': 'S', 'key': 'str', 'event_key': 'str', 'event_value': 'str'}
+            dtypes={'timestamps': 'S', 'key': 'str', 'event_frame': 'str', 'event_key': 'str', 'event_value': 'str'}
         )
         
         # File is not open by default in case of multiple acquisitions per software run
@@ -369,8 +369,15 @@ class FurnaceController():
         if not self.acquiring:
             return
         frame = self.packet_decoder.data['frame']
-        # Values are strings as you cannot have multiple data types in one field
-        self.event_buffer.append({'event_frame': str(frame), 'event_key': key, 'event_value': str(value)})
+        # If the frame is unavailable for some reason - e.g. set a parameter right after acq start
+        if frame is None:
+            frame = 'unknown'
+        # event_values are strings as you cannot have multiple data types in one field
+        # event_frames are strings to allow for obvious 'unknown' instead of -1
+        # Careful handling of the event data is required anyway so this is not burdensome to parse
+        self.event_buffer.append(
+            {'event_frame': str(frame), 'event_key': key, 'event_value': str(value)}
+        )
 
     @run_on_executor
     def background_stream_task(self):

--- a/control/src/livex/mockModbusClient.py
+++ b/control/src/livex/mockModbusClient.py
@@ -302,9 +302,44 @@ class MockTCPClient:
         pass
 
     def recv(self, buffersize):
+        """Generate a binary packet that matches LiveXPacketDecoder format.
+        
+        The packet contains 16 floats (64 bytes) packed as: f ffffffff ffffffff
+        - frame (counter)
+        - temperature_upper, output_upper, kp_upper, ki_upper, kd_upper, lastInput_upper, outputSum_upper, setpoint_upper
+        - temperature_lower, output_lower, kp_lower, ki_lower, kd_lower, lastInput_lower, outputSum_lower, setpoint_lower
+        """
         self.counter += 1
-        temp = self.plc.temp
-        return [self.counter, temp]
+        
+        # Generate simulated data
+        temp_upper = self.plc.temp
+        temp_lower = self.plc.temp - 2  # Simulate lower thermocouple reading lower
+        output_upper = self.plc.output
+        output_lower = self.plc.output * 0.8  # Simulate lower output slightly different
+        setpoint_upper = self.plc.client.registers.get(modAddr.pid_setpoint_upper_hold, 30.0)
+        
+        # Pack 16 floats directly using struct format: f ffffffff ffffffff
+        payload = struct.pack(
+            'f ffffffff ffffffff',
+            float(self.counter),        # frame (1 float)
+            temp_upper,                 # temperature_upper
+            output_upper,               # output_upper
+            0.3,                        # kp_upper
+            0.02,                       # ki_upper
+            0.0,                        # kd_upper
+            0.0,                        # lastInput_upper
+            self.plc.outputSum,         # outputSum_upper
+            setpoint_upper,             # setpoint_upper (8 floats)
+            temp_lower,                 # temperature_lower
+            output_lower,               # output_lower
+            0.3,                        # kp_lower
+            0.02,                       # ki_lower
+            0.0,                        # kd_lower
+            0.0,                        # lastInput_lower
+            self.plc.outputSum,         # outputSum_lower
+            setpoint_upper              # setpoint_upper (repeated, 8 floats)
+        )
+        return payload
 
     def close(self):
         pass


### PR DESCRIPTION
Closes #84 by addressing the consistent and relevant issues from that PR.

- Sequencer ID is updated by +1 before being used, so the first file from a fresh install should be 0 instead of -1. It is also no longer reset by running an acquisition without the sequencer.
- The sequence ID works in the metadata yaml. It might have before but with the -1 reset it was very hard to tell.
- Event_data's frame is now a string to handle None cases which can happen if you change a value right after starting an acquisition - it takes a few seconds for everything to be configured during which you could get event_data without having a frame to refer to. Given the special handling required for the event data anyway, it shouldn't be burdensome to check this when reading it back.
- The fake client uses the same packet system as the real one so you can simulate writing files with actual content.