### PR TITLE
I12 furnace controls

### DIFF
--- a/control/src/livex/acquisition/controller.py
+++ b/control/src/livex/acquisition/controller.py
@@ -235,7 +235,10 @@ class LiveXController(BaseController):
         :param acquisitions: (dict) {name: bool} to determine which acquisitions are to be run
         """
         self.acquiring = True
-        self.current_acquisition = acquisitions
+        if self.furnace.force_solo_acquisition:
+            self.current_acquisition = ['furnace']
+        else:
+            self.current_acquisition = acquisitions
 
         # Get self.filepaths set to
         self._generate_experiment_filenames()

--- a/control/src/livex/furnace/controller.py
+++ b/control/src/livex/furnace/controller.py
@@ -114,8 +114,8 @@ class FurnaceController():
         self.acquiring = False
 
         self.tc_manager = ThermocoupleManager(options)
-        self.pid_upper = PID(modAddr.addresses_pid_upper, pid_defaults, self.max_setpoint, self.max_setpoint_increase, self)
-        self.pid_lower = PID(modAddr.addresses_pid_lower, pid_defaults, self.max_setpoint, self.max_setpoint_increase, self)
+        self.pid_upper = PID(modAddr.addresses_pid_upper, pid_defaults, self.power_output_scale_upper, self)
+        self.pid_lower = PID(modAddr.addresses_pid_lower, pid_defaults, self.power_output_scale_lower, self)
         self.gradient = Gradient(modAddr.gradient_addresses, self)
         self.aspc = AutoSetPointControl(modAddr.aspc_addresses, max_autosp_rate, self)
 
@@ -173,6 +173,7 @@ class FurnaceController():
             'pid_lower': self.pid_lower.tree,
             'max_setpoint_increase': (lambda:
                 self.max_setpoint_increase, self.set_max_setpoint_increase, {'min':1}),
+            'max_setpoint': (lambda: self.max_setpoint, self.set_max_setpoint),
             'autosp': self.aspc.tree,
             'gradient': self.gradient.tree,
             'tcp': self.tcp_subtree,
@@ -183,6 +184,15 @@ class FurnaceController():
             'thermocouples': self.tc_manager.tree
         })
 
+    def set_max_setpoint(self, value):
+        """Set the maximum setpoint allowed for the heaters.
+        This affects both PIDs and is written to the PLC for use there.
+        :param value: new maximum setpoint as a float
+        """
+        self.max_setpoint = value
+        write_modbus_float(self.mod_client, self.max_setpoint, modAddr.setpoint_limit_hold)
+        write_coil(self.mod_client, modAddr.setpoint_update_coil, True)
+
     def set_max_setpoint_increase(self, value):
         """Set the maximum setpoint increase for both PID objects.
 
@@ -191,8 +201,7 @@ class FurnaceController():
         :param value: value to set the max_setpoint_increase to
         """
         self.max_setpoint_increase = value
-        self.pid_upper.max_setpt_step = self.max_setpoint_increase
-        self.pid_lower.max_setpt_step = self.max_setpoint_increase
+        write_modbus_float(self.mod_client, self.max_setpoint_increase, modAddr.setpoint_step_hold)
 
     def cleanup(self):
         """Clean up the FurnaceController instance.
@@ -516,6 +525,9 @@ class FurnaceController():
 
                     self.pid_upper.setpoint = read_decode_holding_reg(self.mod_client, modAddr.pid_setpoint_upper_hold)
                     self.pid_lower.setpoint = read_decode_holding_reg(self.mod_client, modAddr.pid_lower_setpoint_hold)
+
+                    self.max_setpoint = read_decode_holding_reg(self.mod_client, modAddr.setpoint_limit_hold)
+                    self.max_setpoint_increase = read_decode_holding_reg(self.mod_client, modAddr.setpoint_step_hold)
 
                 except Exception as e:
                     logging.error(f"error in reading: {e}")

--- a/control/src/livex/furnace/controller.py
+++ b/control/src/livex/furnace/controller.py
@@ -46,6 +46,9 @@ class FurnaceController():
         max_autosp_rate = int(options.get('max_autosp_rate', 8))
 
         self.allow_solo_acquisition = bool(int(options.get('allow_furnace_only_acquisition', 0)))
+        self.force_solo_acquisition = bool(int(options.get('force_furnace_only_acquisition', 0)))
+        if self.force_solo_acquisition:
+            self.allow_solo_acquisition = True
         self.allow_pid_override = bool(int(options.get('allow_pid_override', 0)))
 
         self.power_output_scale = float(options.get('power_output_scale', 1))

--- a/control/src/livex/furnace/controller.py
+++ b/control/src/livex/furnace/controller.py
@@ -51,9 +51,14 @@ class FurnaceController():
             self.allow_solo_acquisition = True
         self.allow_pid_override = bool(int(options.get('allow_pid_override', 0)))
 
-        self.power_output_scale = float(options.get('power_output_scale', 1))
-        if self.power_output_scale < 0: self.power_output_scale = 0
-        elif self.power_output_scale > 1: self.power_output_scale = 1
+        self.power_output_scale_upper = float(options.get('power_output_scale_upper', 1))
+        self.power_output_scale_lower = float(options.get('power_output_scale_lower', 1))
+        if self.power_output_scale_lower < 0 or self.power_output_scale_lower > 1:
+            logging.warning("power_output_scale_lower should be between 0 and 1. Defaulting to 1.")
+            self.power_output_scale_lower = 1
+        if self.power_output_scale_upper < 0 or self.power_output_scale_upper > 1:
+            logging.warning("power_output_scale_upper should be between 0 and 1. Defaulting to 1.")
+            self.power_output_scale_upper = 1
 
         self.ip = options.get('ip', '192.168.0.159')
         self.port = int(options.get('port', '4444'))
@@ -316,7 +321,8 @@ class FurnaceController():
 
             write_modbus_float(self.mod_client, self.max_setpoint_increase, modAddr.setpoint_step_hold)
             write_modbus_float(self.mod_client, self.max_setpoint, modAddr.setpoint_limit_hold)
-            write_modbus_float(self.mod_client, self.power_output_scale, modAddr.power_output_scale)
+            write_modbus_float(self.mod_client, self.power_output_scale_upper, modAddr.power_output_scale_upper)
+            write_modbus_float(self.mod_client, self.power_output_scale_lower, modAddr.power_output_scale_lower)
             write_coil(self.mod_client, modAddr.setpoint_update_coil, True)
 
             self.connected = True

--- a/control/src/livex/furnace/controls/pid.py
+++ b/control/src/livex/furnace/controls/pid.py
@@ -7,7 +7,7 @@ class PID():
     It stores the values, and provides functions to write to the modbus server on the PLC.
     """
 
-    def __init__(self, addresses, pid_defaults, max_setpoint, max_setpoint_increase, furnace_controller):
+    def __init__(self, addresses, pid_defaults, power_scalar,furnace_controller):
         """Initialise the PID class with addresses, creating the Parameter Tree and its
         required parameters to be populated when a modbus connection is established via the 
         controller.
@@ -15,9 +15,6 @@ class PID():
         # Addresses are generic via dictionary usage. Particularly important here for two PIDs
         self.addresses = addresses
         self.pid_defaults = pid_defaults
-
-        # Maximum amount setpoint can increase by in one step. Min.1 because SP must be changeable
-        self.max_setpt_step = max_setpoint_increase if max_setpoint_increase >= 1 else 1
 
         self.enable = False
         self.setpoint = 0.0
@@ -31,12 +28,13 @@ class PID():
 
         self.override_percent = 0
         self.override_enable = False
+        self.power_scalar = power_scalar
 
         self.furnace_controller = furnace_controller
 
         self.tree = ParameterTree({
             'enable': (lambda: self.enable, self.set_enable),
-            'setpoint': (lambda: self.setpoint, self.set_setpoint, {'max': max_setpoint}),
+            'setpoint': (lambda: self.setpoint, self.set_setpoint),
             'proportional': (lambda: self.kp, self.set_proportional),
             'integral': (lambda: self.ki, self.set_integral),
             'derivative': (lambda: self.kd, self.set_derivative),
@@ -47,8 +45,14 @@ class PID():
                 'percent_out': (lambda: self.override_percent, self.set_override_percent,
                                 {'min': 0, 'max': 100}),
                 'enable': (lambda: self.override_enable, self.set_override_enable)
-            }
+            },
+            'output_scalar': (lambda: self.power_scalar, self.set_power_scalar)
         })
+
+    def set_power_scalar(self, value):
+        """Set the power scalar for the PID output."""
+        self.power_scalar = value
+        write_modbus_float(self.client, self.power_scalar, self.addresses['power_output_scale_upper'])
 
     def set_override_percent(self, value):
         """Set the % output on the PID override."""
@@ -100,9 +104,11 @@ class PID():
 
     def set_setpoint(self, value):
         """Set the setpoint of the PID."""
-        if (value - self.setpoint) > self.max_setpt_step:
+        if (value - self.setpoint) > self.furnace_controller.max_setpt_step:
             # Limit is increase-only, safety considerations and cooling has no thermal shock risk
             raise LiveXError("Temperature step size exceeds limit.")
+        if value > self.furnace_controller.max_setpoint:
+            raise LiveXError("Setpoint exceeds maximum limit.")
         self.setpoint = value
         write_modbus_float(
             self.client, value, self.addresses['setpoint']

--- a/control/src/livex/furnace/controls/pid.py
+++ b/control/src/livex/furnace/controls/pid.py
@@ -52,7 +52,7 @@ class PID():
     def set_power_scalar(self, value):
         """Set the power scalar for the PID output."""
         self.power_scalar = value
-        write_modbus_float(self.client, self.power_scalar, self.addresses['power_output_scale_upper'])
+        write_modbus_float(self.client, self.power_scalar, self.addresses['output_scalar'])
 
     def set_override_percent(self, value):
         """Set the % output on the PID override."""
@@ -104,7 +104,7 @@ class PID():
 
     def set_setpoint(self, value):
         """Set the setpoint of the PID."""
-        if (value - self.setpoint) > self.furnace_controller.max_setpt_step:
+        if (value - self.setpoint) > self.furnace_controller.max_setpoint_increase:
             # Limit is increase-only, safety considerations and cooling has no thermal shock risk
             raise LiveXError("Temperature step size exceeds limit.")
         if value > self.furnace_controller.max_setpoint:

--- a/control/src/livex/modbusAddresses.py
+++ b/control/src/livex/modbusAddresses.py
@@ -113,7 +113,8 @@ class modAddr():
         'output_override': output_override_upper_hold,
         'output_override_enable': output_override_upper_coil,
         'max_setpoint': setpoint_limit_hold,
-        'max_setpoint_step': setpoint_step_hold
+        'max_setpoint_step': setpoint_step_hold,
+        'output_scalar': power_output_scale_upper
     }
 
     addresses_pid_lower = {
@@ -129,7 +130,8 @@ class modAddr():
         'output_override': output_override_lower_hold,
         'output_override_enable': output_override_lower_coil,
         'max_setpoint': setpoint_limit_hold,
-        'max_setpoint_step': setpoint_step_hold
+        'max_setpoint_step': setpoint_step_hold,
+        'output_scalar': power_output_scale_lower
     }
 
     gradient_addresses = {

--- a/control/src/livex/modbusAddresses.py
+++ b/control/src/livex/modbusAddresses.py
@@ -96,7 +96,8 @@ class modAddr():
     output_override_upper_hold  = 40055
     output_override_lower_hold  = 40057
 
-    power_output_scale          = 40059
+    power_output_scale_upper    = 40059
+    power_output_scale_lower    = 40061
 
     # Addresses for controls
     addresses_pid_upper = {

--- a/control/test/config/livex.cfg
+++ b/control/test/config/livex.cfg
@@ -66,7 +66,8 @@ kd_default = 0.1
 # Power output scale - the furnace scales its voltage output from the PID's 1-100 calculation
 # using this 0-1 value. i.e. 0.8 means that 100 PID output gives you 8V of the 0-10V output
 # Generally, what you do with this could be done with PID tuning, but this may be
-power_output_scale = 1
+power_output_scale_upper = 0.8
+power_output_scale_lower = 0.5
 
 # thermocouple type and index/enable
 # index refers to order they are connected on hardware: 0x60, 0x67->0x63.

--- a/control/test/config/livex.cfg
+++ b/control/test/config/livex.cfg
@@ -51,6 +51,9 @@ monitor_retention = 60
 
 # If enabled, furnace_only_acquistion option is allowed. Without it, the functionality is disabled.
 allow_furnace_only_acquisition = 0
+# If enabled, allow_furnace_only_acquisition is true, and all _start_acquisition() calls in the
+# acquisition adapter will only use the furnace, ignoring other sources such as cameras
+force_furnace_only_acquisition = 1
 # If enabled, manual override of the PID outputs is enabled as an option.
 allow_pid_override = 0
 
@@ -128,8 +131,8 @@ module = munir.adapter.MunirAdapter
 fp_mode = 1
 subsystems = 
 # widefov, narrowfov
-widefov_endpoints = 
-narrowfov_endpoints = 
+widefov_endpoints =
+narrowfov_endpoints =
 odin_data_config_path = test/config
 # Comms timeout
 ctrl_timeout = 1.0
@@ -143,7 +146,7 @@ liveview_control = 0
 module = orca_quest.adapter.OrcaAdapter
 # Connections are defined by endpoint and given names as reference.
 # To remove a connection, remove the endpoint. Give each a name. Excess names are not used.
-camera_endpoint = 
+camera_endpoint =
 camera_name = widefov, narrowfov
 
 status_bg_task_enable = 1

--- a/control/test/config/livex.cfg
+++ b/control/test/config/livex.cfg
@@ -66,8 +66,8 @@ kd_default = 0.1
 # Power output scale - the furnace scales its voltage output from the PID's 1-100 calculation
 # using this 0-1 value. i.e. 0.8 means that 100 PID output gives you 8V of the 0-10V output
 # Generally, what you do with this could be done with PID tuning, but this may be
-power_output_scale_upper = 0.8
-power_output_scale_lower = 0.5
+power_output_scale_upper = 0.9
+power_output_scale_lower = 0.9
 
 # thermocouple type and index/enable
 # index refers to order they are connected on hardware: 0x60, 0x67->0x63.

--- a/control/test/static/livex-vite/src/App.jsx
+++ b/control/test/static/livex-vite/src/App.jsx
@@ -65,7 +65,7 @@ function App() {
       <Row>
         <Motors
           endpoint_url={endpoint_url}
-         />
+        />
       </Row>
     </OdinApp>
   );

--- a/control/test/static/livex-vite/src/components/furnace/FurnaceMeta.jsx
+++ b/control/test/static/livex-vite/src/components/furnace/FurnaceMeta.jsx
@@ -1,0 +1,68 @@
+import { Col, Row, Form, FloatingLabel } from 'react-bootstrap';
+import { TitleCard, WithEndpoint } from 'odin-react';
+import { floatingInputStyle } from '../../utils';
+
+const EndPointFormControl = WithEndpoint(Form.Control);
+
+function FurnaceMeta(props) {
+    const {furnaceEndPoint } = props;
+    const {connectedDisable} = props;
+
+    return (
+      <TitleCard title={
+        <Row>
+          <Col xs={6} className="d-flex align-items-center" style={{fontSize:'1.3rem'}}>Furnace Settings</Col>
+        </Row>
+      }>
+        <Col>
+          <Row>
+            <Col xs={6}>
+              <FloatingLabel label="Max Setpoint">
+                <EndPointFormControl
+                  endpoint={furnaceEndPoint}
+                  fullpath={"max_setpoint"}
+                  disabled={connectedDisable}
+                  style={floatingInputStyle}
+                />
+              </FloatingLabel>
+            </Col>
+            <Col xs={6}>
+              <FloatingLabel label="Max Setpoint Increase">
+                <EndPointFormControl
+                  endpoint={furnaceEndPoint}
+                  fullpath={"max_setpoint_increase"}
+                  disabled={connectedDisable}
+                  style={floatingInputStyle}
+                />
+              </FloatingLabel>
+            </Col>
+          </Row>
+          <Row className="mt-3">
+            <Col xs={6}>
+              <FloatingLabel label="Upper Output Power Scalar">
+                <EndPointFormControl
+                  endpoint={furnaceEndPoint}
+                  fullpath={"pid_upper/output_scalar"}
+                  disabled={connectedDisable}
+                  style={floatingInputStyle}
+                />
+              </FloatingLabel>
+            </Col>
+            <Col xs={6}>
+              <FloatingLabel label="Lower Output Power Scalar">
+                <EndPointFormControl
+                  endpoint={furnaceEndPoint}
+                  fullpath={"pid_lower/output_scalar"}
+                  disabled={connectedDisable}
+                  style={floatingInputStyle}
+                />
+              </FloatingLabel>
+            </Col>
+          </Row>
+        </Col>
+          
+      </TitleCard>
+    )
+}
+
+export default FurnaceMeta;

--- a/control/test/static/livex-vite/src/components/furnace/FurnacePage.jsx
+++ b/control/test/static/livex-vite/src/components/furnace/FurnacePage.jsx
@@ -12,6 +12,7 @@ import AutoSetPointControl from './AutoSetPointControl';
 import InfoPanel from './InfoPanel';
 import FurnaceRecording from './FurnaceRecording';
 import PidOverride from './PidOverride';
+import FurnaceMeta from './FurnaceMeta';
 
 function FurnacePage(props){
     
@@ -93,6 +94,11 @@ function FurnacePage(props){
             <></>
           }
 
+          <FurnaceMeta
+            furnaceEndPoint={furnaceEndPoint}
+            connectedDisable={connectedDisable}
+          />
+
           {
             furnaceEndPoint.data.status?.allow_solo_acquisition ?
             <FurnaceRecording
@@ -101,7 +107,6 @@ function FurnacePage(props){
             :
             <></>
           }
-
         </Col>
         <Col md={6}>
 

--- a/control/test/static/livex-vite/src/components/furnace/InfoPanel.jsx
+++ b/control/test/static/livex-vite/src/components/furnace/InfoPanel.jsx
@@ -92,7 +92,7 @@ function InfoPanel(props) {
                 </InputGroup.Text>
                 <InputGroup.Text
                   style={labelStyling}>
-                    {checkNull((furnaceEndPoint.data?.pid_upper?.output) * 0.1)}
+                    {checkNull((furnaceEndPoint.data?.pid_upper?.output) * 0.1 * furnaceEndPoint.data?.pid_upper?.output_scalar)}
                 </InputGroup.Text>
               </InputGroup>
             </Row>
@@ -163,7 +163,7 @@ function InfoPanel(props) {
                 </InputGroup.Text>
                 <InputGroup.Text
                   style={labelStyling}>
-                    {checkNull((furnaceEndPoint.data?.pid_lower?.output) * 0.1)}
+                    {checkNull((furnaceEndPoint.data?.pid_lower?.output) * 0.1 * furnaceEndPoint.data?.pid_lower?.output_scalar)}
                 </InputGroup.Text>
               </InputGroup>
             </Row>

--- a/control/test/static/livex-vite/src/components/furnace/PidControl.jsx
+++ b/control/test/static/livex-vite/src/components/furnace/PidControl.jsx
@@ -106,16 +106,6 @@ function PidControl(props) {
                       />
                     </FloatingLabel>
                   </Col>
-                  <Col>
-                    <FloatingLabel label="Max Increase">
-                      <EndPointFormControl
-                        endpoint={furnaceEndPoint}
-                        fullpath={"max_setpoint_increase"}
-                        disabled={connectedDisable}
-                        style={floatingInputStyle}
-                      />
-                    </FloatingLabel>
-                  </Col>
                 </Row>
                 <Row>
                   <Col xs={8} sm={6}>

--- a/firmware/livex/include/config.h
+++ b/firmware/livex/include/config.h
@@ -11,7 +11,7 @@
 #define INVERT_OUTPUT_SIGNAL false
 
 // true: use external interrupt instead of internal timer
-#define USE_EXTERNAL_INTERRUPT true
+#define USE_EXTERNAL_INTERRUPT false
 // true: output total of external interrupts at given range (e.g.: every 100 interrupts. 100, 200, etc.)
 #define LOG_INTERRUPTS true
 #define LOG_INTERRUPTS_INTERVAL 50
@@ -125,7 +125,8 @@
 
 #define MOD_OUTPUT_OVERRIDE_UPPER_HOLD 40055
 #define MOD_OUTPUT_OVERRIDE_LOWER_HOLD 40057
-#define MOD_POWER_OUTPUT_SCALE 40059
+#define MOD_POWER_OUTPUT_SCALE_UPPER_HOLD 40059
+#define MOD_POWER_OUTPUT_SCALE_LOWER_HOLD 40061
 
 #define PIN_PWM_UPPER A0_5
 #define PIN_PWM_LOWER A0_6

--- a/firmware/livex/include/pidController.h
+++ b/firmware/livex/include/pidController.h
@@ -22,6 +22,7 @@ struct PIDAddresses
   int modKiHold;
   int modKdHold;
   int modOutputOverrideHold;
+  int modOutputScaleHold;
 };
 
 
@@ -33,6 +34,7 @@ class PIDController
     double baseSetPoint;
     float gradientModifier = 0;
     float autospRate = 0;
+    float power_output_scale;
 
     PID myPID_;
     PIDAddresses addr_;
@@ -40,6 +42,7 @@ class PIDController
     PIDController(PIDAddresses addr);
     void run();
     void check_PID_tunings(double newKp, double newKi, double newKd);
+    void check_output_scale(float new_scale);
 };
 
 #endif

--- a/firmware/livex/src/main.cpp
+++ b/firmware/livex/src/main.cpp
@@ -29,7 +29,8 @@ PIDAddresses pidUpper_addr = {
   MOD_KP_UPPER_HOLD,
   MOD_KI_UPPER_HOLD,
   MOD_KD_UPPER_HOLD,
-  MOD_OUTPUT_OVERRIDE_UPPER_HOLD
+  MOD_OUTPUT_OVERRIDE_UPPER_HOLD,
+  MOD_POWER_OUTPUT_SCALE_UPPER_HOLD
 };
 
 PIDAddresses pidLower_addr = {
@@ -42,7 +43,8 @@ PIDAddresses pidLower_addr = {
   MOD_KP_LOWER_HOLD,
   MOD_KI_LOWER_HOLD,
   MOD_KD_LOWER_HOLD,
-  MOD_OUTPUT_OVERRIDE_LOWER_HOLD
+  MOD_OUTPUT_OVERRIDE_LOWER_HOLD,
+  MOD_POWER_OUTPUT_SCALE_LOWER_HOLD
 };
 
 PIDController PID_upper(pidUpper_addr);
@@ -74,8 +76,6 @@ volatile int interruptCounter = 0;
 // Communicated via modbus
 float interruptFrequency = 10;
 float setpointLimit = DEFAULT_SETPOINT_LIMIT;  // Maximum temperature setpoint
-
-float power_output_scale = POWER_OUTPUT_SCALE;
 
 void IRAM_ATTR pidFlagOnTimer()
 {
@@ -116,7 +116,8 @@ void setup()
   // Also write in some safe defaults to be overridden when adapter is started
   modbus_server.floatToHoldingRegisters(MOD_SETPOINT_LIMIT_HOLD, setpointLimit);
   modbus_server.floatToHoldingRegisters(MOD_SETPOINT_STEP_HOLD, DEFAULT_SETPOINT_STEP_LIMIT);
-  modbus_server.floatToHoldingRegisters(MOD_POWER_OUTPUT_SCALE, power_output_scale);
+  modbus_server.floatToHoldingRegisters(MOD_POWER_OUTPUT_SCALE_UPPER_HOLD, POWER_OUTPUT_SCALE);
+  modbus_server.floatToHoldingRegisters(MOD_POWER_OUTPUT_SCALE_LOWER_HOLD, POWER_OUTPUT_SCALE);
 
   // Write default indices for active thermocouples, assume in order
   for (int i=0; i<num_mcp; i++)

--- a/firmware/livex/src/pidController.cpp
+++ b/firmware/livex/src/pidController.cpp
@@ -10,6 +10,7 @@ PIDController::PIDController(PIDAddresses addr) : myPID_(&input, &output, &setPo
     Ki = PID_KI_DEFAULT;
     Kd = PID_KD_DEFAULT;
     addr_ = addr;
+    power_output_scale = POWER_OUTPUT_SCALE;
 
     // Set PID output range to match ESP3258PLC PWM
     myPID_.SetOutputLimits(0, PID_OUTPUT_LIMIT);
@@ -25,7 +26,7 @@ void PIDController::run()
     myPID_.Compute();
 }
 
- // Check if PID terms in registers are different, and set them accordingly
+// Check if PID terms in registers are different, and set them accordingly
 void PIDController::check_PID_tunings(double newKp, double newKi, double newKd)
 {
     if ((newKp != Kp) || (newKi != Ki) || (newKd != Kd)) 
@@ -35,4 +36,19 @@ void PIDController::check_PID_tunings(double newKp, double newKi, double newKd)
       Ki = newKi;
       Kd = newKd;
     }
+}
+
+// Check PID output scalar and change if it differs from the current value
+void PIDController::check_output_scale(float new_scale)
+{
+    if (new_scale != power_output_scale)
+    {
+        power_output_scale = new_scale;
+        if (DEBUG)
+        {
+            Serial.print("New power output scale: ");
+            Serial.println(power_output_scale);
+        }
+    }
+
 }

--- a/firmware/livex/src/taskComms.cpp
+++ b/firmware/livex/src/taskComms.cpp
@@ -139,6 +139,27 @@ void updateSetPoints()
     PID_lower.baseSetPoint = newLowerSp;
   }
 
+  // If the maximum setpoint is lowered and the setpoints themselves are not updated,
+  // clamp any existing base setpoints to the new limit.
+  bool clamped = false;
+  if (PID_upper.baseSetPoint > setpointLimit)
+  {
+    PID_upper.baseSetPoint = setpointLimit;
+    clamped = true;
+  }
+  if (PID_lower.baseSetPoint > setpointLimit)
+  {
+    PID_lower.baseSetPoint = setpointLimit;
+    clamped = true;
+  }
+
+  // Write the values to the registers so this is reflected in the UI
+  if (clamped)
+  {
+    modbus_server.floatToHoldingRegisters(MOD_SETPOINT_UPPER_HOLD, PID_upper.baseSetPoint);
+    modbus_server.floatToHoldingRegisters(MOD_SETPOINT_LOWER_HOLD, PID_lower.baseSetPoint);
+  }
+
   // When setpoints are updated, thermal gradient will also need adjusting as modifiers will change
   thermalGradient();
 

--- a/firmware/livex/src/taskComms.cpp
+++ b/firmware/livex/src/taskComms.cpp
@@ -166,19 +166,6 @@ void updateSetPoints()
     }
   }
 
-  // Additional check - has the power output scalar been changed?
-  // Better to have this check in here than with its own flag, as it is updated very very rarely
-  power_output_scale = modbus_server.combineHoldingRegisters(MOD_POWER_OUTPUT_SCALE);
-  if (power_output_scale < 0) { power_output_scale = 0; }
-  else if (power_output_scale > 1) { power_output_scale = 1; }
-
-  if (DEBUG)
-  {
-    Serial.print("New baseSetPoint for Upper PID: ");
-    Serial.println(PID_upper.baseSetPoint);
-    Serial.print("New baseSetPoint for Lower PID: ");
-    Serial.println(PID_lower.baseSetPoint);
-  }
   // Set coil back to 0 to prevent continuously calling this function
   modbus_server.writeBool(MOD_SETPOINT_UPDATE_COIL, 0);
 }

--- a/firmware/livex/src/taskPid.cpp
+++ b/firmware/livex/src/taskPid.cpp
@@ -193,6 +193,10 @@ void runPID(PIDEnum pid = PIDEnum::UNKNOWN)
     double newKd = double(modbus_server.combineHoldingRegisters(addr.modKdHold));
     PID->check_PID_tunings(newKp, newKi, newKd);
 
+    // Check power output scalar. This won't change often but is not intensive to check
+    float new_scale = modbus_server.combineHoldingRegisters(addr.modOutputScaleHold);
+    PID->check_output_scale(new_scale);
+
     // Setpoint and computation handling
     // The goal here is that the setPoint used in PID computation is always derived from the
     // baseSetPoint of the PID. the bSP is gotten from a register in taskComms when changed,
@@ -215,7 +219,7 @@ void runPID(PIDEnum pid = PIDEnum::UNKNOWN)
     // The value output is still 0->4095 bits representing 0->10V
     // But we want to scale this down to 80% of the available range
     float out = POWER_OUTPUT_BITS * PID->output / PID_OUTPUT_LIMIT;
-    out = out * power_output_scale;
+    out = out * PID->power_output_scale;
 
     // Write PID output. When PID is not enabled, 
     modbus_server.floatToInputRegisters(addr.modPidOutputInp, PID->output);


### PR DESCRIPTION
Add a few requested controls to the furnace.

- Config option to force a furnace-only acquisition. This, in the `start_acquisition()` function of the acquisition controller, replaces whatever values are passed in with just 'furnace'. This does not affect the triggers and these will all be triggered as normal, it just prevents anything other than the furnace being configured.
- Power output scalar can be adjusted for each heater (for the case that you may have, as example, a 40V and 60V heater connected at once)
- Maximum setpoint is now adjustable outside of the config file
- Furnace settings box which contains the power output scalars and max setpoint, along with max setpoint increase which is moved down to prevent duplication. Arguably, output scale is a heater control but it's not useful for the active running of the system so I've kept it separate
- Monitor/Info Panel PLC Voltage uses the power output scalar for its voltage estimate, in lieu of the future reading taken directly from the supply
- The PLC code has been updated correspondingly. This doesn't make many changes, but the output scale is now a property of the PidController class, and changing it is part of runPID instead of taskComms. 
- Related, decreasing the maximum setpoint below the current setpoint of the system clamps those values down to the maximum, to prevent a situation where you decrease the maximum and become unable to easily change the values back, especially when considering the ASPC logic. And because it makes more sense to do it this way generally